### PR TITLE
publish pod address even before they are ready.

### DIFF
--- a/helm/templates/headless-service.yaml
+++ b/helm/templates/headless-service.yaml
@@ -16,6 +16,9 @@ spec:
     - name: election
       port: {{ int .Values.config.electionPort }}
       targetPort: election
+  {{- if .Values.hostNetwork }}
+  publishNotReadyAddresses: true
+  {{- end }}
   selector:
     app: {{ template "zookeeper.name" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
zookeeper pods fails to start when `hostNetwork` is enabled. 
```
2023-01-25 12:21:57,431 [myid:3] - ERROR [ListenerHandler-zookeeper-2.zookeeper-headless.traceable.svc.cluster.local:3888:QuorumCnxManager$Listener$ListenerHandler@1099] - Exception while listening
java.net.SocketException: Unresolved address
  at java.base/java.net.ServerSocket.bind(Unknown Source)
  at java.base/java.net.ServerSocket.bind(Unknown Source)
  at org.apache.zookeeper.server.quorum.QuorumCnxManager$Listener$ListenerHandler.createNewServerSocket(QuorumCnxManager.java:1141)
  at org.apache.zookeeper.server.quorum.QuorumCnxManager$Listener$ListenerHandler.acceptConnections(QuorumCnxManager.java:1070)
  at org.apache.zookeeper.server.quorum.QuorumCnxManager$Listener$ListenerHandler.run(QuorumCnxManager.java:1039)
  at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
  at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
  at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
  at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
  at java.base/java.lang.Thread.run(Unknown Source)
```