### PR TITLE
upgrade zookeeper to version 3.8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest AS downloader
 
-ARG ZOOKEEPER_VERSION=3.7.1
+ARG ZOOKEEPER_VERSION=3.8.1
 
 RUN apk add --update curl gpg gpg-agent && \
     curl -sLO https://www.apache.org/dist/zookeeper/KEYS && \

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: zookeeper
 type: application
 description: zookeeper helm chart
-appVersion: 3.4.10
+appVersion: 3.8.1
 version: 0.1.0

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -145,7 +145,7 @@ prometheus:
     enabled: false
     image:
       repository: hypertrace/prometheus-jmx-exporter
-      tag: 0.1.1
+      tag: 0.1.2
       pullPolicy: IfNotPresent
     port: 5556
     resources:


### PR DESCRIPTION
Fixes the following vulnerabilities:
1. CVE-2022-2047
2. CVE-2022-2097
3. CVE-2022-24823
4. CVE-2022-42003
5. CVE-2022-42004
6. CVE-2022-4304
7. CVE-2022-4450
8. CVE-2023-0215
9. CVE-2023-0286