### PR TITLE
upgrade zookeeper to version 3.8.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest AS downloader
 
-ARG ZOOKEEPER_VERSION=3.8.1
+ARG ZOOKEEPER_VERSION=3.8.3
 
 RUN apk add --update curl gpg gpg-agent && \
     curl -sLO https://www.apache.org/dist/zookeeper/KEYS && \

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: zookeeper
 type: application
 description: zookeeper helm chart
-appVersion: 3.8.1
+appVersion: 3.8.3
 version: 0.1.0

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -145,7 +145,7 @@ prometheus:
     enabled: false
     image:
       repository: hypertrace/prometheus-jmx-exporter
-      tag: 0.1.3
+      tag: 0.1.4
       pullPolicy: IfNotPresent
     port: 5556
     resources:


### PR DESCRIPTION
fixes the following vulnerabilities:
```
hypertrace/zookeeper:0.2.5 (ubuntu 22.04)

Total: 54 (UNKNOWN: 0, LOW: 36, MEDIUM: 13, HIGH: 5, CRITICAL: 0)

┌──────────────────┬────────────────┬──────────┬──────────┬──────────────────────────────┬─────────────────────┬─────────────────────────────────────────────────────────────┐
│     Library      │ Vulnerability  │ Severity │  Status  │      Installed Version       │    Fixed Version    │                            Title                            │
├──────────────────┼────────────────┼──────────┼──────────┼──────────────────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────┤
│ bash             │ CVE-2022-3715  │ LOW      │ affected │ 5.1-6ubuntu1                 │                     │ a heap-buffer-overflow in valid_parameter_transform         │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2022-3715                   │
├──────────────────┼────────────────┤          │          ├──────────────────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────┤
│ coreutils        │ CVE-2016-2781  │          │          │ 8.32-4.1ubuntu1              │                     │ coreutils: Non-privileged session can escape to the parent  │
│                  │                │          │          │                              │                     │ session in chroot                                           │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2016-2781                   │
├──────────────────┼────────────────┼──────────┼──────────┼──────────────────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────┤
│ curl             │ CVE-2023-38545 │ HIGH     │ fixed    │ 7.81.0-1ubuntu1.10           │ 7.81.0-1ubuntu1.14  │ curl: heap based buffer overflow in the SOCKS5 proxy        │
│                  │                │          │          │                              │                     │ handshake                                                   │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-38545                  │
│                  ├────────────────┼──────────┤          │                              ├─────────────────────┼─────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-28321 │ LOW      │          │                              │ 7.81.0-1ubuntu1.11  │ curl: IDN wildcard match may lead to Improper Cerificate    │
│                  │                │          │          │                              │                     │ Validation                                                  │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-28321                  │
│                  ├────────────────┤          │          │                              │                     ├─────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-28322 │          │          │                              │                     │ curl: more POST-after-PUT confusion                         │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-28322                  │
│                  ├────────────────┤          │          │                              ├─────────────────────┼─────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-38546 │          │          │                              │ 7.81.0-1ubuntu1.14  │ curl: cookie injection with none file                       │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-38546                  │
├──────────────────┼────────────────┤          ├──────────┼──────────────────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────┤
│ gcc-12-base      │ CVE-2022-27943 │          │ affected │ 12.1.0-2ubuntu1~22.04        │                     │ libiberty/rust-demangle.c in GNU GCC 11.2 allows stack      │
│                  │                │          │          │                              │                     │ exhaustion in demangle_const                                │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2022-27943                  │
├──────────────────┼────────────────┤          │          ├──────────────────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────┤
│ gpgv             │ CVE-2022-3219  │          │          │ 2.2.27-3ubuntu2.1            │                     │ denial of service issue (resource consumption) using        │
│                  │                │          │          │                              │                     │ compressed packets                                          │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2022-3219                   │
├──────────────────┼────────────────┼──────────┼──────────┼──────────────────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────┤
│ libc-bin         │ CVE-2023-4911  │ HIGH     │ fixed    │ 2.35-0ubuntu3.1              │ 2.35-0ubuntu3.4     │ glibc: buffer overflow in ld.so leading to privilege        │
│                  │                │          │          │                              │                     │ escalation                                                  │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-4911                   │
│                  ├────────────────┼──────────┼──────────┤                              ├─────────────────────┼─────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-5156  │ MEDIUM   │ affected │                              │                     │ glibc: DoS due to memory leak in getaddrinfo.c              │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-5156                   │
│                  ├────────────────┼──────────┤          │                              ├─────────────────────┼─────────────────────────────────────────────────────────────┤
│                  │ CVE-2016-20013 │ LOW      │          │                              │                     │ sha256crypt and sha512crypt through 0.6 allow attackers to  │
│                  │                │          │          │                              │                     │ cause a denial of...                                        │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2016-20013                  │
│                  ├────────────────┤          │          │                              ├─────────────────────┼─────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-4806  │          │          │                              │                     │ glibc: potential use-after-free in getaddrinfo()            │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-4806                   │
│                  ├────────────────┤          │          │                              ├─────────────────────┼─────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-4813  │          │          │                              │                     │ glibc: potential use-after-free in gaih_inet()              │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-4813                   │
├──────────────────┼────────────────┼──────────┼──────────┤                              ├─────────────────────┼─────────────────────────────────────────────────────────────┤
│ libc6            │ CVE-2023-4911  │ HIGH     │ fixed    │                              │ 2.35-0ubuntu3.4     │ glibc: buffer overflow in ld.so leading to privilege        │
│                  │                │          │          │                              │                     │ escalation                                                  │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-4911                   │
│                  ├────────────────┼──────────┼──────────┤                              ├─────────────────────┼─────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-5156  │ MEDIUM   │ affected │                              │                     │ glibc: DoS due to memory leak in getaddrinfo.c              │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-5156                   │
│                  ├────────────────┼──────────┤          │                              ├─────────────────────┼─────────────────────────────────────────────────────────────┤
│                  │ CVE-2016-20013 │ LOW      │          │                              │                     │ sha256crypt and sha512crypt through 0.6 allow attackers to  │
│                  │                │          │          │                              │                     │ cause a denial of...                                        │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2016-20013                  │
│                  ├────────────────┤          │          │                              ├─────────────────────┼─────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-4806  │          │          │                              │                     │ glibc: potential use-after-free in getaddrinfo()            │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-4806                   │
│                  ├────────────────┤          │          │                              ├─────────────────────┼─────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-4813  │          │          │                              │                     │ glibc: potential use-after-free in gaih_inet()              │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-4813                   │
├──────────────────┼────────────────┼──────────┼──────────┼──────────────────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────┤
│ libcurl4         │ CVE-2023-38545 │ HIGH     │ fixed    │ 7.81.0-1ubuntu1.10           │ 7.81.0-1ubuntu1.14  │ curl: heap based buffer overflow in the SOCKS5 proxy        │
│                  │                │          │          │                              │                     │ handshake                                                   │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-38545                  │
│                  ├────────────────┼──────────┤          │                              ├─────────────────────┼─────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-28321 │ LOW      │          │                              │ 7.81.0-1ubuntu1.11  │ curl: IDN wildcard match may lead to Improper Cerificate    │
│                  │                │          │          │                              │                     │ Validation                                                  │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-28321                  │
│                  ├────────────────┤          │          │                              │                     ├─────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-28322 │          │          │                              │                     │ curl: more POST-after-PUT confusion                         │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-28322                  │
│                  ├────────────────┤          │          │                              ├─────────────────────┼─────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-38546 │          │          │                              │ 7.81.0-1ubuntu1.14  │ curl: cookie injection with none file                       │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-38546                  │
├──────────────────┼────────────────┤          ├──────────┼──────────────────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────┤
│ libgcc-s1        │ CVE-2022-27943 │          │ affected │ 12.1.0-2ubuntu1~22.04        │                     │ libiberty/rust-demangle.c in GNU GCC 11.2 allows stack      │
│                  │                │          │          │                              │                     │ exhaustion in demangle_const                                │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2022-27943                  │
├──────────────────┼────────────────┼──────────┼──────────┼──────────────────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────┤
│ libgnutls30      │ CVE-2023-5981  │ MEDIUM   │ fixed    │ 3.7.3-4ubuntu1.2             │ 3.7.3-4ubuntu1.3    │ [ttiming side-channel inside RSA-PSK key exchange]          │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-5981                   │
├──────────────────┼────────────────┤          │          ├──────────────────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────┤
│ libgssapi-krb5-2 │ CVE-2023-36054 │          │          │ 1.19.2-2ubuntu0.2            │ 1.19.2-2ubuntu0.3   │ krb5: Denial of service through freeing uninitialized       │
│                  │                │          │          │                              │                     │ pointer                                                     │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-36054                  │
├──────────────────┤                │          │          │                              │                     │                                                             │
│ libk5crypto3     │                │          │          │                              │                     │                                                             │
│                  │                │          │          │                              │                     │                                                             │
│                  │                │          │          │                              │                     │                                                             │
├──────────────────┤                │          │          │                              │                     │                                                             │
│ libkrb5-3        │                │          │          │                              │                     │                                                             │
│                  │                │          │          │                              │                     │                                                             │
│                  │                │          │          │                              │                     │                                                             │
├──────────────────┤                │          │          │                              │                     │                                                             │
│ libkrb5support0  │                │          │          │                              │                     │                                                             │
│                  │                │          │          │                              │                     │                                                             │
│                  │                │          │          │                              │                     │                                                             │
├──────────────────┼────────────────┼──────────┼──────────┼──────────────────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────┤
│ libldap-2.5-0    │ CVE-2023-2953  │ LOW      │ affected │ 2.5.14+dfsg-0ubuntu0.22.04.2 │                     │ null pointer dereference in ber_memalloc_x function         │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-2953                   │
├──────────────────┼────────────────┼──────────┤          ├──────────────────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────┤
│ liblzma5         │ CVE-2020-22916 │ MEDIUM   │          │ 5.2.5-2ubuntu1               │                     │ Denial of service via decompression of crafted file         │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2020-22916                  │
├──────────────────┼────────────────┤          ├──────────┼──────────────────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────┤
│ libnghttp2-14    │ CVE-2023-44487 │          │ fixed    │ 1.43.0-1build3               │ 1.43.0-1ubuntu0.1   │ HTTP/2: Multiple HTTP/2 enabled web servers are vulnerable  │
│                  │                │          │          │                              │                     │ to a DDoS attack...                                         │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-44487                  │
├──────────────────┼────────────────┼──────────┼──────────┼──────────────────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────┤
│ libpcre3         │ CVE-2017-11164 │ LOW      │ affected │ 2:8.39-13ubuntu0.22.04.1     │                     │ OP_KETRMAX feature in the match function in pcre_exec.c     │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2017-11164                  │
├──────────────────┼────────────────┤          │          ├──────────────────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────┤
│ libpng16-16      │ CVE-2022-3857  │          │          │ 1.6.37-3build5               │                     │ Null pointer dereference leads to segmentation fault        │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2022-3857                   │
├──────────────────┼────────────────┤          ├──────────┼──────────────────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────┤
│ libprocps8       │ CVE-2023-4016  │          │ fixed    │ 2:3.3.17-6ubuntu2            │ 2:3.3.17-6ubuntu2.1 │ procps: ps buffer overflow                                  │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-4016                   │
├──────────────────┼────────────────┼──────────┤          ├──────────────────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────┤
│ libssl3          │ CVE-2023-5363  │ MEDIUM   │          │ 3.0.2-0ubuntu1.10            │ 3.0.2-0ubuntu1.12   │ openssl: Incorrect cipher key and IV length processing      │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-5363                   │
│                  ├────────────────┼──────────┤          │                              │                     ├─────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-2975  │ LOW      │          │                              │                     │ openssl: AES-SIV cipher implementation contains a bug that  │
│                  │                │          │          │                              │                     │ causes it to ignore...                                      │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-2975                   │
│                  ├────────────────┤          │          │                              │                     ├─────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-3446  │          │          │                              │                     │ openssl: Excessive time spent checking DH keys and          │
│                  │                │          │          │                              │                     │ parameters                                                  │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-3446                   │
│                  ├────────────────┤          │          │                              │                     ├─────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-3817  │          │          │                              │                     │ OpenSSL: Excessive time spent checking DH q parameter value │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-3817                   │
├──────────────────┼────────────────┤          ├──────────┼──────────────────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────┤
│ libstdc++6       │ CVE-2022-27943 │          │ affected │ 12.1.0-2ubuntu1~22.04        │                     │ libiberty/rust-demangle.c in GNU GCC 11.2 allows stack      │
│                  │                │          │          │                              │                     │ exhaustion in demangle_const                                │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2022-27943                  │
├──────────────────┼────────────────┤          │          ├──────────────────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────┤
│ libzstd1         │ CVE-2022-4899  │          │          │ 1.4.8+dfsg-3build1           │                     │ zstd: mysql: buffer overrun in util.c                       │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2022-4899                   │
├──────────────────┼────────────────┼──────────┼──────────┼──────────────────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────┤
│ locales          │ CVE-2023-4911  │ HIGH     │ fixed    │ 2.35-0ubuntu3.1              │ 2.35-0ubuntu3.4     │ glibc: buffer overflow in ld.so leading to privilege        │
│                  │                │          │          │                              │                     │ escalation                                                  │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-4911                   │
│                  ├────────────────┼──────────┼──────────┤                              ├─────────────────────┼─────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-5156  │ MEDIUM   │ affected │                              │                     │ glibc: DoS due to memory leak in getaddrinfo.c              │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-5156                   │
│                  ├────────────────┼──────────┤          │                              ├─────────────────────┼─────────────────────────────────────────────────────────────┤
│                  │ CVE-2016-20013 │ LOW      │          │                              │                     │ sha256crypt and sha512crypt through 0.6 allow attackers to  │
│                  │                │          │          │                              │                     │ cause a denial of...                                        │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2016-20013                  │
│                  ├────────────────┤          │          │                              ├─────────────────────┼─────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-4806  │          │          │                              │                     │ glibc: potential use-after-free in getaddrinfo()            │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-4806                   │
│                  ├────────────────┤          │          │                              ├─────────────────────┼─────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-4813  │          │          │                              │                     │ glibc: potential use-after-free in gaih_inet()              │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-4813                   │
├──────────────────┼────────────────┤          │          ├──────────────────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────┤
│ login            │ CVE-2023-29383 │          │          │ 1:4.8.1-2ubuntu2.1           │                     │ Improper input validation in shadow-utils package utility   │
│                  │                │          │          │                              │                     │ chfn                                                        │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-29383                  │
├──────────────────┼────────────────┼──────────┼──────────┼──────────────────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────┤
│ openssl          │ CVE-2023-5363  │ MEDIUM   │ fixed    │ 3.0.2-0ubuntu1.10            │ 3.0.2-0ubuntu1.12   │ openssl: Incorrect cipher key and IV length processing      │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-5363                   │
│                  ├────────────────┼──────────┤          │                              │                     ├─────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-2975  │ LOW      │          │                              │                     │ openssl: AES-SIV cipher implementation contains a bug that  │
│                  │                │          │          │                              │                     │ causes it to ignore...                                      │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-2975                   │
│                  ├────────────────┤          │          │                              │                     ├─────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-3446  │          │          │                              │                     │ openssl: Excessive time spent checking DH keys and          │
│                  │                │          │          │                              │                     │ parameters                                                  │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-3446                   │
│                  ├────────────────┤          │          │                              │                     ├─────────────────────────────────────────────────────────────┤
│                  │ CVE-2023-3817  │          │          │                              │                     │ OpenSSL: Excessive time spent checking DH q parameter value │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-3817                   │
├──────────────────┼────────────────┤          ├──────────┼──────────────────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────┤
│ passwd           │ CVE-2023-29383 │          │ affected │ 1:4.8.1-2ubuntu2.1           │                     │ Improper input validation in shadow-utils package utility   │
│                  │                │          │          │                              │                     │ chfn                                                        │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-29383                  │
├──────────────────┼────────────────┤          │          ├──────────────────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────┤
│ perl-base        │ CVE-2022-48522 │          │          │ 5.34.0-3ubuntu1.2            │                     │ stack-based crash in S_find_uninit_var()                    │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2022-48522                  │
├──────────────────┼────────────────┤          ├──────────┼──────────────────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────┤
│ procps           │ CVE-2023-4016  │          │ fixed    │ 2:3.3.17-6ubuntu2            │ 2:3.3.17-6ubuntu2.1 │ procps: ps buffer overflow                                  │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2023-4016                   │
├──────────────────┼────────────────┼──────────┼──────────┼──────────────────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────┤
│ wget             │ CVE-2021-31879 │ MEDIUM   │ affected │ 1.21.2-2ubuntu1              │                     │ authorization header disclosure on redirect                 │
│                  │                │          │          │                              │                     │ https://avd.aquasec.com/nvd/cve-2021-31879                  │
└──────────────────┴────────────────┴──────────┴──────────┴──────────────────────────────┴─────────────────────┴─────────────────────────────────────────────────────────────┘
2023-11-27T12:06:11.244+0530	INFO	Table result includes only package filenames. Use '--format json' option to get the full path to the package file.

Java (jar)

Total: 9 (UNKNOWN: 0, LOW: 1, MEDIUM: 5, HIGH: 2, CRITICAL: 1)

┌─────────────────────────────────────────────────────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────────────────────────┬──────────────────────────────────────────────────────────────┐
│                         Library                         │ Vulnerability  │ Severity │ Status │ Installed Version │                  Fixed Version                   │                            Title                             │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ io.netty:netty-handler (netty-handler-4.1.86.Final.jar) │ CVE-2023-34462 │ MEDIUM   │ fixed  │ 4.1.86.Final      │ 4.1.94.Final                                     │ netty: SniHandler 16MB allocation leads to OOM               │
│                                                         │                │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-34462                   │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┤        ├───────────────────┼──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.apache.zookeeper:zookeeper (zookeeper-3.8.1.jar)    │ CVE-2023-44981 │ CRITICAL │        │ 3.8.1             │ 3.7.2, 3.8.3, 3.9.1                              │ zookeeper: Authorization Bypass in Apache ZooKeeper          │
│                                                         │                │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-44981                   │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┤        ├───────────────────┼──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.eclipse.jetty:jetty-http                            │ CVE-2023-40167 │ MEDIUM   │        │ 9.4.49.v20220914  │ 9.4.52, 10.0.16, 11.0.16, 12.0.1                 │ jetty: Improper validation of HTTP/1 content-length          │
│ (jetty-http-9.4.49.v20220914.jar)                       │                │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-40167                   │
├─────────────────────────────────────────────────────────┼────────────────┤          │        │                   ├──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.eclipse.jetty:jetty-server                          │ CVE-2023-26048 │          │        │                   │ 9.4.51.v20230217, 10.0.14, 11.0.14               │ jetty-server: OutOfMemoryError for large multipart without   │
│ (jetty-server-9.4.49.v20220914.jar)                     │                │          │        │                   │                                                  │ filename read via request.getParameter()                     │
│                                                         │                │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-26048                   │
│                                                         ├────────────────┼──────────┤        │                   ├──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2023-26049 │ LOW      │        │                   │ 9.4.51.v20230217, 10.0.14, 11.0.14, 12.0.0.beta0 │ jetty-server: Cookie parsing of quoted values can exfiltrate │
│                                                         │                │          │        │                   │                                                  │ values from other cookies...                                 │
│                                                         │                │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-26049                   │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┤        ├───────────────────┼──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.xerial.snappy:snappy-java (snappy-java-1.1.7.7.jar) │ CVE-2023-34455 │ HIGH     │        │ 1.1.7.7           │ 1.1.10.1                                         │ snappy-java: Unchecked chunk length leads to DoS             │
│                                                         │                │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-34455                   │
│                                                         ├────────────────┤          │        │                   ├──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2023-43642 │          │        │                   │ 1.1.10.4                                         │ snappy-java: Missing upper bound check on chunk length in    │
│                                                         │                │          │        │                   │                                                  │ snappy-java can lead...                                      │
│                                                         │                │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-43642                   │
│                                                         ├────────────────┼──────────┤        │                   ├──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2023-34453 │ MEDIUM   │        │                   │ 1.1.10.1                                         │ snappy-java: Integer overflow in shuffle leads to DoS        │
│                                                         │                │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-34453                   │
│                                                         ├────────────────┤          │        │                   │                                                  ├──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2023-34454 │          │        │                   │                                                  │ snappy-java: Integer overflow in compress leads to DoS       │
│                                                         │                │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-34454                   │
└─────────────────────────────────────────────────────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────────────────────────┴──────────────────────────────────────────────────────────────┘
```